### PR TITLE
Fix Unicode decoding issue with accented characters and special symbols

### DIFF
--- a/pywinstyles/py_win_style.py
+++ b/pywinstyles/py_win_style.py
@@ -202,7 +202,12 @@ class apply_dnd():
                 files = []
                 for i in range(count):
                     func_DragQueryFile(typ(wp), i, file_buffer, sizeof(file_buffer))
-                    drop_name = file_buffer.value.decode("utf-8")
+                    try:
+                        drop_name = file_buffer.value.decode("utf-8")
+                    except UnicodeDecodeError:
+                        # If UTF-8 decoding fails, attempt to decode with a different encoding (e.g., Windows-1252)
+                        drop_name = file_buffer.value.decode("Windows-1252")
+                     
                     files.append(drop_name)
                 func(files)
                 windll.shell32.DragFinish(typ(wp))


### PR DESCRIPTION
This pull request addresses the issue with accented characters and special symbols in file paths during the drag-and-drop process.

Changes made:

   - Modified the py_drop_func to handle Unicode decoding errors.
   - Initially attempts to decode the file path using UTF-8 encoding.
   - If UTF-8 decoding fails (e.g., due to accented characters), it falls back to Windows-1252 encoding.

This fix ensures that file paths with characters like á, é, í, ó, ú, ñ, and others are handled correctly without causing errors.

This should address and close Issue #42.